### PR TITLE
Replace `help` and `list` recipes in justfile with call to `just -l`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,4 @@
+# requires githubcontrib (https://github.com/mgechev/github-contributors-list)
 @update-contributors:
 	echo 'Removing old appendix-00-contributors.md'
 	mv src/appendix-00-contributors.md appendix-00-contributors.md.bak
@@ -16,13 +17,5 @@ clean:
 	find . -type f -name "*.bk" -exec rm {} \;
 	find . -type f -name ".*~" -exec rm {} \;
 
-@help: list
-
-@list:
-	echo 'Available commands:'
-	echo
-	echo -e '\tupdate-contributors'
-	echo -e '\t\trequires: githubcontrib (https://github.com/mgechev/github-contributors-list)
-	echo -e '\tbuild'
-	echo -e '\tclean'
-	echo -e '\tlist | help'
+@help:
+	just -l


### PR DESCRIPTION
I low-key stalk just users, sorry for the random pull request :)

I noticed that you added a `list` recipe to your justfile. Just actually supports a `--list` / `-l` flag which will print available recipes. Also, it treats a comment before a recipe as a doc comment, and will print it out when you list recipes. Here's what it looks like after this PR, which changes the help recipe to just call `just -l`:

```
: just help
Available recipes:
    build
    clean
    help
    update-contributors # requires githubcontrib (https://github.com/mgechev/github-contributors-list)
```